### PR TITLE
Fix typo in TopShelf code sample

### DIFF
--- a/Cluster.WebCrawler/README.md
+++ b/Cluster.WebCrawler/README.md
@@ -396,7 +396,7 @@ class Program
             x.RunAsLocalSystem();
             x.StartAutomatically();
             //x.UseNLog();
-            x.Service<CrawlerService>();
+            x.Service<TrackerService>();
             x.EnableServiceRecovery(r => r.RestartService(1));
         });
     }


### PR DESCRIPTION
I believe there is a typo in the TopShelf code sample where the service type should be TrackerService instead of the CrawlerService.