### PR TITLE
Update Cluster.WebCrawler to Akka v1.2.2

### DIFF
--- a/Cluster.WebCrawler/src/WebCrawler.CrawlService/App.config
+++ b/Cluster.WebCrawler/src/WebCrawler.CrawlService/App.config
@@ -18,8 +18,8 @@
               log-remote-lifecycle-events = DEBUG
               log-received-messages = on
               
-              helios.tcp {
-                transport-class = "Akka.Remote.Transport.Helios.HeliosTcpTransport, Akka.Remote"
+              dot-netty.tcp {
+                transport-class = "Akka.Remote.Transport.DotNetty.TcpTransport, Akka.Remote"
 		            applied-adapters = []
 		            transport-protocol = tcp
                 #will be populated with a dynamic host-name at runtime if left uncommented
@@ -43,7 +43,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.1.37.0" newVersion="1.1.37.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Cluster.WebCrawler/src/WebCrawler.CrawlService/CrawlService.cs
+++ b/Cluster.WebCrawler/src/WebCrawler.CrawlService/CrawlService.cs
@@ -15,7 +15,7 @@ namespace WebCrawler.CrawlService
 
         public bool Stop(HostControl hostControl)
         {
-            ClusterSystem.Shutdown();
+            ClusterSystem.Terminate();
             return true;
         }
     }

--- a/Cluster.WebCrawler/src/WebCrawler.CrawlService/WebCrawler.CrawlService.csproj
+++ b/Cluster.WebCrawler/src/WebCrawler.CrawlService/WebCrawler.CrawlService.csproj
@@ -32,17 +32,29 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Akka, Version=1.1.3.31, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Akka.1.1.3\lib\net45\Akka.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Akka, Version=1.2.2.39, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Akka.1.2.2\lib\net45\Akka.dll</HintPath>
     </Reference>
-    <Reference Include="Akka.Cluster, Version=1.1.3.31, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Akka.Cluster.1.1.3\lib\net45\Akka.Cluster.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Akka.Cluster, Version=1.2.2.40, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Akka.Cluster.1.2.2\lib\net45\Akka.Cluster.dll</HintPath>
     </Reference>
-    <Reference Include="Akka.Remote, Version=1.1.3.31, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Akka.Remote.1.1.3\lib\net45\Akka.Remote.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Akka.Remote, Version=1.2.2.40, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Akka.Remote.1.2.2\lib\net45\Akka.Remote.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetty.Buffers, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Buffers.0.4.3\lib\net45\DotNetty.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetty.Codecs, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs.0.4.3\lib\net45\DotNetty.Codecs.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetty.Common, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Common.0.4.3\lib\net45\DotNetty.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetty.Handlers, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Handlers.0.4.3\lib\net45\DotNetty.Handlers.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetty.Transport, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Transport.0.4.3\lib\net45\DotNetty.Transport.dll</HintPath>
     </Reference>
     <Reference Include="Google.ProtocolBuffers, Version=2.4.1.555, Culture=neutral, PublicKeyToken=55f7125234beb589, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Google.ProtocolBuffers.2.4.1.555\lib\net40\Google.ProtocolBuffers.dll</HintPath>
@@ -59,16 +71,31 @@
     <Reference Include="HtmlAgilityPack">
       <HintPath>..\..\packages\HtmlAgilityPack.1.4.9\lib\Net45\HtmlAgilityPack.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.1.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Logging.1.1.1\lib\netstandard1.1\Microsoft.Extensions.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Logging.Abstractions.1.1.1\lib\netstandard1.1\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Collections.Immutable.1.1.37\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/Cluster.WebCrawler/src/WebCrawler.CrawlService/packages.config
+++ b/Cluster.WebCrawler/src/WebCrawler.CrawlService/packages.config
@@ -1,21 +1,53 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Akka" version="1.1.3" targetFramework="net45" />
-  <package id="Akka.Cluster" version="1.1.3" targetFramework="net45" />
-  <package id="Akka.Remote" version="1.1.3" targetFramework="net45" />
+  <package id="Akka" version="1.2.2" targetFramework="net45" />
+  <package id="Akka.Cluster" version="1.2.2" targetFramework="net45" />
+  <package id="Akka.Remote" version="1.2.2" targetFramework="net45" />
+  <package id="DotNetty.Buffers" version="0.4.3" targetFramework="net45" />
+  <package id="DotNetty.Codecs" version="0.4.3" targetFramework="net45" />
+  <package id="DotNetty.Common" version="0.4.3" targetFramework="net45" />
+  <package id="DotNetty.Handlers" version="0.4.3" targetFramework="net45" />
+  <package id="DotNetty.Transport" version="0.4.3" targetFramework="net45" />
   <package id="Google.ProtocolBuffers" version="2.4.1.555" targetFramework="net45" />
   <package id="Helios" version="2.1.2" targetFramework="net45" />
   <package id="HtmlAgilityPack" version="1.4.9" targetFramework="net45" />
   <package id="Microsoft.Bcl.Immutable" version="1.0.34" targetFramework="net45" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.1.0" targetFramework="net45" />
+  <package id="Microsoft.Extensions.Logging" version="1.1.1" targetFramework="net45" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="1.1.1" targetFramework="net45" />
+  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net45" />
+  <package id="NETStandard.Library" version="1.6.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="System.Collections" version="4.0.0" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net45" />
-  <package id="System.Diagnostics.Debug" version="4.0.0" targetFramework="net45" />
-  <package id="System.Globalization" version="4.0.0" targetFramework="net45" />
-  <package id="System.Linq" version="4.0.0" targetFramework="net45" />
-  <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net45" />
-  <package id="System.Runtime" version="4.0.0" targetFramework="net45" />
-  <package id="System.Runtime.Extensions" version="4.0.0" targetFramework="net45" />
-  <package id="System.Threading" version="4.0.0" targetFramework="net45" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net45" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net45" />
+  <package id="System.ComponentModel" version="4.3.0" targetFramework="net45" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net45" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net45" />
+  <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net45" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net45" />
+  <package id="System.IO" version="4.3.0" targetFramework="net45" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net45" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net45" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net45" />
+  <package id="System.Net.Http" version="4.3.0" targetFramework="net45" />
+  <package id="System.Net.Primitives" version="4.3.0" targetFramework="net45" />
+  <package id="System.ObjectModel" version="4.3.0" targetFramework="net45" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net45" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net45" />
+  <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net45" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net45" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net45" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net45" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net45" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net45" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net45" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net45" />
+  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net45" />
+  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net45" />
+  <package id="System.Threading" version="4.3.0" targetFramework="net45" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net45" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net45" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net45" />
   <package id="Topshelf" version="3.2.0" targetFramework="net45" />
 </packages>

--- a/Cluster.WebCrawler/src/WebCrawler.Messages/WebCrawler.Shared.csproj
+++ b/Cluster.WebCrawler/src/WebCrawler.Messages/WebCrawler.Shared.csproj
@@ -30,18 +30,16 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Akka, Version=1.1.3.31, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Akka.1.1.3\lib\net45\Akka.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Akka, Version=1.2.2.39, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Akka.1.2.2\lib\net45\Akka.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.36.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Collections.Immutable.1.1.36\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/Cluster.WebCrawler/src/WebCrawler.Messages/packages.config
+++ b/Cluster.WebCrawler/src/WebCrawler.Messages/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Akka" version="1.1.3" targetFramework="net45" />
+  <package id="Akka" version="1.2.2" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net45" />
 </packages>

--- a/Cluster.WebCrawler/src/WebCrawler.Service/App.config
+++ b/Cluster.WebCrawler/src/WebCrawler.Service/App.config
@@ -52,8 +52,8 @@
 							log-remote-lifecycle-events = DEBUG
 							log-received-messages = on
 							
-							helios.tcp {
-								transport-class = "Akka.Remote.Transport.Helios.HeliosTcpTransport, Akka.Remote"
+							dot-netty.tcp {
+								transport-class = "Akka.Remote.Transport.DotNetty.TcpTransport, Akka.Remote"
 								applied-adapters = []
 								transport-protocol = tcp
 								#will be populated with a dynamic host-name at runtime if left uncommented
@@ -77,7 +77,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.1.37.0" newVersion="1.1.37.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Cluster.WebCrawler/src/WebCrawler.Service/TrackerService.cs
+++ b/Cluster.WebCrawler/src/WebCrawler.Service/TrackerService.cs
@@ -23,7 +23,7 @@ namespace WebCrawler.TrackingService
 
         public bool Stop(HostControl hostControl)
         {
-            ClusterSystem.Shutdown();
+            ClusterSystem.Terminate();
             return true;
         }
     }

--- a/Cluster.WebCrawler/src/WebCrawler.Service/WebCrawler.TrackingService.csproj
+++ b/Cluster.WebCrawler/src/WebCrawler.Service/WebCrawler.TrackingService.csproj
@@ -32,17 +32,29 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Akka, Version=1.1.3.31, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Akka.1.1.3\lib\net45\Akka.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Akka, Version=1.2.2.39, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Akka.1.2.2\lib\net45\Akka.dll</HintPath>
     </Reference>
-    <Reference Include="Akka.Cluster, Version=1.1.3.31, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Akka.Cluster.1.1.3\lib\net45\Akka.Cluster.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Akka.Cluster, Version=1.2.2.40, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Akka.Cluster.1.2.2\lib\net45\Akka.Cluster.dll</HintPath>
     </Reference>
-    <Reference Include="Akka.Remote, Version=1.1.3.31, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Akka.Remote.1.1.3\lib\net45\Akka.Remote.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Akka.Remote, Version=1.2.2.40, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Akka.Remote.1.2.2\lib\net45\Akka.Remote.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetty.Buffers, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Buffers.0.4.3\lib\net45\DotNetty.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetty.Codecs, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs.0.4.3\lib\net45\DotNetty.Codecs.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetty.Common, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Common.0.4.3\lib\net45\DotNetty.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetty.Handlers, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Handlers.0.4.3\lib\net45\DotNetty.Handlers.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetty.Transport, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Transport.0.4.3\lib\net45\DotNetty.Transport.dll</HintPath>
     </Reference>
     <Reference Include="Google.ProtocolBuffers, Version=2.4.1.555, Culture=neutral, PublicKeyToken=55f7125234beb589, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Google.ProtocolBuffers.2.4.1.555\lib\net40\Google.ProtocolBuffers.dll</HintPath>
@@ -59,17 +71,31 @@
     <Reference Include="HtmlAgilityPack">
       <HintPath>..\..\packages\HtmlAgilityPack.1.4.9\lib\Net45\HtmlAgilityPack.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.1.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Logging.1.1.1\lib\netstandard1.1\Microsoft.Extensions.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Logging.Abstractions.1.1.1\lib\netstandard1.1\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Collections.Immutable.1.1.37\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/Cluster.WebCrawler/src/WebCrawler.Service/packages.config
+++ b/Cluster.WebCrawler/src/WebCrawler.Service/packages.config
@@ -1,21 +1,53 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Akka" version="1.1.3" targetFramework="net45" />
-  <package id="Akka.Cluster" version="1.1.3" targetFramework="net45" />
-  <package id="Akka.Remote" version="1.1.3" targetFramework="net45" />
+  <package id="Akka" version="1.2.2" targetFramework="net45" />
+  <package id="Akka.Cluster" version="1.2.2" targetFramework="net45" />
+  <package id="Akka.Remote" version="1.2.2" targetFramework="net45" />
+  <package id="DotNetty.Buffers" version="0.4.3" targetFramework="net45" />
+  <package id="DotNetty.Codecs" version="0.4.3" targetFramework="net45" />
+  <package id="DotNetty.Common" version="0.4.3" targetFramework="net45" />
+  <package id="DotNetty.Handlers" version="0.4.3" targetFramework="net45" />
+  <package id="DotNetty.Transport" version="0.4.3" targetFramework="net45" />
   <package id="Google.ProtocolBuffers" version="2.4.1.555" targetFramework="net45" />
   <package id="Helios" version="2.1.2" targetFramework="net45" />
   <package id="HtmlAgilityPack" version="1.4.9" targetFramework="net45" />
   <package id="Microsoft.Bcl.Immutable" version="1.0.34" targetFramework="net45" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.1.0" targetFramework="net45" />
+  <package id="Microsoft.Extensions.Logging" version="1.1.1" targetFramework="net45" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="1.1.1" targetFramework="net45" />
+  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net45" />
+  <package id="NETStandard.Library" version="1.6.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="System.Collections" version="4.0.0" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net45" />
-  <package id="System.Diagnostics.Debug" version="4.0.0" targetFramework="net45" />
-  <package id="System.Globalization" version="4.0.0" targetFramework="net45" />
-  <package id="System.Linq" version="4.0.0" targetFramework="net45" />
-  <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net45" />
-  <package id="System.Runtime" version="4.0.0" targetFramework="net45" />
-  <package id="System.Runtime.Extensions" version="4.0.0" targetFramework="net45" />
-  <package id="System.Threading" version="4.0.0" targetFramework="net45" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net45" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net45" />
+  <package id="System.ComponentModel" version="4.3.0" targetFramework="net45" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net45" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net45" />
+  <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net45" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net45" />
+  <package id="System.IO" version="4.3.0" targetFramework="net45" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net45" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net45" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net45" />
+  <package id="System.Net.Http" version="4.3.0" targetFramework="net45" />
+  <package id="System.Net.Primitives" version="4.3.0" targetFramework="net45" />
+  <package id="System.ObjectModel" version="4.3.0" targetFramework="net45" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net45" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net45" />
+  <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net45" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net45" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net45" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net45" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net45" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net45" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net45" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net45" />
+  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net45" />
+  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net45" />
+  <package id="System.Threading" version="4.3.0" targetFramework="net45" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net45" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net45" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net45" />
   <package id="Topshelf" version="3.2.0" targetFramework="net45" />
 </packages>

--- a/Cluster.WebCrawler/src/WebCrawler.Shared.IO/WebCrawler.Shared.IO.csproj
+++ b/Cluster.WebCrawler/src/WebCrawler.Shared.IO/WebCrawler.Shared.IO.csproj
@@ -35,13 +35,11 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Akka, Version=1.1.3.31, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Akka.1.1.3\lib\net45\Akka.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Akka, Version=1.2.2.39, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Akka.1.2.2\lib\net45\Akka.dll</HintPath>
     </Reference>
-    <Reference Include="Akka.Streams, Version=1.1.3.32, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Akka.Streams.1.1.3.32-beta\lib\net45\Akka.Streams.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Akka.Streams, Version=1.2.2.40, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Akka.Streams.1.2.2\lib\net45\Akka.Streams.dll</HintPath>
     </Reference>
     <Reference Include="HtmlAgilityPack">
       <HintPath>..\..\packages\HtmlAgilityPack.1.4.9\lib\Net45\HtmlAgilityPack.dll</HintPath>
@@ -50,14 +48,12 @@
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Reactive.Streams, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Reactive.Streams.1.0.0-RC1\lib\portable-net45+netcore45\Reactive.Streams.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Reactive.Streams, Version=1.0.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Reactive.Streams.1.0.2\lib\net45\Reactive.Streams.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.36.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Collections.Immutable.1.1.36\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />
@@ -78,6 +74,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/Cluster.WebCrawler/src/WebCrawler.Shared.IO/app.config
+++ b/Cluster.WebCrawler/src/WebCrawler.Shared.IO/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Cluster.WebCrawler/src/WebCrawler.Shared.IO/packages.config
+++ b/Cluster.WebCrawler/src/WebCrawler.Shared.IO/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Akka" version="1.1.3" targetFramework="net45" />
-  <package id="Akka.Streams" version="1.1.3.32-beta" targetFramework="net45" />
+  <package id="Akka" version="1.2.2" targetFramework="net45" />
+  <package id="Akka.Streams" version="1.2.2" targetFramework="net45" />
   <package id="HtmlAgilityPack" version="1.4.9" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="Reactive.Streams" version="1.0.0-RC1" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net45" />
+  <package id="Reactive.Streams" version="1.0.2" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net45" />
 </packages>

--- a/Cluster.WebCrawler/src/WebCrawler.Web/Web.config
+++ b/Cluster.WebCrawler/src/WebCrawler.Web/Web.config
@@ -55,7 +55,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-1.1.37.0" newVersion="1.1.37.0" />
+				<bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
 			</dependentAssembly>
 		</assemblyBinding>
 	</runtime>
@@ -83,8 +83,8 @@
 						remote {
 							log-remote-lifecycle-events = DEBUG
 							
-							helios.tcp {
-								transport-class = "Akka.Remote.Transport.Helios.HeliosTcpTransport, Akka.Remote"
+							dot-netty.tcp {
+								transport-class = "Akka.Remote.Transport.DotNetty.TcpTransport, Akka.Remote"
 								applied-adapters = []
 								transport-protocol = tcp
 								#will be populated with a dynamic host-name at runtime if left uncommented

--- a/Cluster.WebCrawler/src/WebCrawler.Web/WebCrawler.Web.csproj
+++ b/Cluster.WebCrawler/src/WebCrawler.Web/WebCrawler.Web.csproj
@@ -40,17 +40,29 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Akka, Version=1.1.3.31, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Akka.1.1.3\lib\net45\Akka.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Akka, Version=1.2.2.39, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Akka.1.2.2\lib\net45\Akka.dll</HintPath>
     </Reference>
-    <Reference Include="Akka.Cluster, Version=1.1.3.31, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Akka.Cluster.1.1.3\lib\net45\Akka.Cluster.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Akka.Cluster, Version=1.2.2.40, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Akka.Cluster.1.2.2\lib\net45\Akka.Cluster.dll</HintPath>
     </Reference>
-    <Reference Include="Akka.Remote, Version=1.1.3.31, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Akka.Remote.1.1.3\lib\net45\Akka.Remote.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Akka.Remote, Version=1.2.2.40, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Akka.Remote.1.2.2\lib\net45\Akka.Remote.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetty.Buffers, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Buffers.0.4.3\lib\net45\DotNetty.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetty.Codecs, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Codecs.0.4.3\lib\net45\DotNetty.Codecs.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetty.Common, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Common.0.4.3\lib\net45\DotNetty.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetty.Handlers, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Handlers.0.4.3\lib\net45\DotNetty.Handlers.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetty.Transport, Version=0.0.0.0, Culture=neutral, PublicKeyToken=bc13ca065fa06c29, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\DotNetty.Transport.0.4.3\lib\net45\DotNetty.Transport.dll</HintPath>
     </Reference>
     <Reference Include="Google.ProtocolBuffers, Version=2.4.1.555, Culture=neutral, PublicKeyToken=55f7125234beb589, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Google.ProtocolBuffers.2.4.1.555\lib\net40\Google.ProtocolBuffers.dll</HintPath>
@@ -71,17 +83,31 @@
       <HintPath>..\..\packages\Microsoft.AspNet.SignalR.SystemWeb.2.2.0\lib\net45\Microsoft.AspNet.SignalR.SystemWeb.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.1.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.1.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Logging.1.1.1\lib\netstandard1.1\Microsoft.Extensions.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Extensions.Logging.Abstractions.1.1.1\lib\netstandard1.1\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Collections.Immutable.1.1.37\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.ApplicationServices" />
@@ -223,7 +249,9 @@
     <Content Include="fonts\glyphicons-halflings-regular.woff" />
     <Content Include="fonts\glyphicons-halflings-regular.ttf" />
     <Content Include="fonts\glyphicons-halflings-regular.eot" />
-    <Content Include="packages.config" />
+    <Content Include="packages.config">
+      <SubType>Designer</SubType>
+    </Content>
     <None Include="Project_Readme.html" />
   </ItemGroup>
   <ItemGroup>

--- a/Cluster.WebCrawler/src/WebCrawler.Web/packages.config
+++ b/Cluster.WebCrawler/src/WebCrawler.Web/packages.config
@@ -1,10 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Akka" version="1.1.3" targetFramework="net45" />
-  <package id="Akka.Cluster" version="1.1.3" targetFramework="net45" />
-  <package id="Akka.Remote" version="1.1.3" targetFramework="net45" />
+  <package id="Akka" version="1.2.2" targetFramework="net45" />
+  <package id="Akka.Cluster" version="1.2.2" targetFramework="net45" />
+  <package id="Akka.Remote" version="1.2.2" targetFramework="net45" />
   <package id="Antlr" version="3.4.1.9004" targetFramework="net45" />
   <package id="bootstrap" version="3.0.0" targetFramework="net45" />
+  <package id="DotNetty.Buffers" version="0.4.3" targetFramework="net45" />
+  <package id="DotNetty.Codecs" version="0.4.3" targetFramework="net45" />
+  <package id="DotNetty.Common" version="0.4.3" targetFramework="net45" />
+  <package id="DotNetty.Handlers" version="0.4.3" targetFramework="net45" />
+  <package id="DotNetty.Transport" version="0.4.3" targetFramework="net45" />
   <package id="Google.ProtocolBuffers" version="2.4.1.555" targetFramework="net45" />
   <package id="Helios" version="2.1.2" targetFramework="net45" />
   <package id="jQuery" version="1.10.2" targetFramework="net45" />
@@ -19,23 +24,50 @@
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net45" />
   <package id="Microsoft.Bcl.Immutable" version="1.0.34" targetFramework="net45" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.1.0" targetFramework="net45" />
+  <package id="Microsoft.Extensions.Logging" version="1.1.1" targetFramework="net45" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="1.1.1" targetFramework="net45" />
   <package id="Microsoft.jQuery.Unobtrusive.Validation" version="3.2.0" targetFramework="net45" />
+  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net45" />
   <package id="Microsoft.Owin" version="2.1.0" targetFramework="net45" />
   <package id="Microsoft.Owin.Host.SystemWeb" version="2.1.0" targetFramework="net45" />
   <package id="Microsoft.Owin.Security" version="2.1.0" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="Modernizr" version="2.6.2" targetFramework="net45" />
+  <package id="NETStandard.Library" version="1.6.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="Respond" version="1.2.0" targetFramework="net45" />
-  <package id="System.Collections" version="4.0.0" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net45" />
-  <package id="System.Diagnostics.Debug" version="4.0.0" targetFramework="net45" />
-  <package id="System.Globalization" version="4.0.0" targetFramework="net45" />
-  <package id="System.Linq" version="4.0.0" targetFramework="net45" />
-  <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net45" />
-  <package id="System.Runtime" version="4.0.0" targetFramework="net45" />
-  <package id="System.Runtime.Extensions" version="4.0.0" targetFramework="net45" />
-  <package id="System.Threading" version="4.0.0" targetFramework="net45" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net45" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net45" />
+  <package id="System.ComponentModel" version="4.3.0" targetFramework="net45" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net45" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net45" />
+  <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net45" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net45" />
+  <package id="System.IO" version="4.3.0" targetFramework="net45" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net45" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net45" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net45" />
+  <package id="System.Net.Http" version="4.3.0" targetFramework="net45" />
+  <package id="System.Net.Primitives" version="4.3.0" targetFramework="net45" />
+  <package id="System.ObjectModel" version="4.3.0" targetFramework="net45" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net45" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net45" />
+  <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net45" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net45" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net45" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net45" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net45" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net45" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net45" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net45" />
+  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net45" />
+  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net45" />
+  <package id="System.Threading" version="4.3.0" targetFramework="net45" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net45" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net45" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net45" />
   <package id="WebGrease" version="1.5.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Update Cluster.WebCrawler to Akka v1.2.2 for Akka, Remote, and Cluster and changed HOCON to use dot-netty.tcp transport