### PR TITLE
limited the number of status messages displayed on the front-end to 2…

### DIFF
--- a/Cluster.WebCrawler/src/WebCrawler.TrackerService/Actors/IO/CrawlMaster.cs
+++ b/Cluster.WebCrawler/src/WebCrawler.TrackerService/Actors/IO/CrawlMaster.cs
@@ -70,7 +70,7 @@ namespace WebCrawler.TrackerService.Actors.IO
         {
             Job = job;
             RunningStatus = new JobStatusUpdate(Job);
-            TotalStats = new CrawlJobStats(Job);
+            TotalStats = new CrawlJobStats(Job).Copy(1); // count the index page as "discovered"
             Context.SetReceiveTimeout(TimeSpan.FromSeconds(5));
             WaitingForTracker();
         }

--- a/Cluster.WebCrawler/src/WebCrawler.Web/Views/Home/Index.cshtml
+++ b/Cluster.WebCrawler/src/WebCrawler.Web/Views/Home/Index.cshtml
@@ -36,6 +36,9 @@
 
             self.addMessage = function(message) {
                 self.messages.unshift({ message: message });
+                if (self.messages().length > 20) {
+                    self.messages.pop(); // create circular-buffer-like behavior
+                }
             };
         }
 


### PR DESCRIPTION
…0 most recent. Fixed n+1 error with discover counts.