### PR TITLE
Update `CrawlService` and `TrackerService` to shutdown gracefully

### DIFF
--- a/Cluster.WebCrawler/src/WebCrawler.CrawlService/Program.cs
+++ b/Cluster.WebCrawler/src/WebCrawler.CrawlService/Program.cs
@@ -9,7 +9,11 @@ namespace WebCrawler.CrawlService
             var crawlerService = new CrawlerService();
             crawlerService.Start();
 
-            Console.CancelKeyPress += (sender, eventArgs) => { crawlerService.Stop(); };
+            Console.CancelKeyPress += (sender, eventArgs) =>
+            {
+                crawlerService.Stop();
+                eventArgs.Cancel = true;
+            };
 
             crawlerService.WhenTerminated.Wait();
         }

--- a/Cluster.WebCrawler/src/WebCrawler.TrackerService/Program.cs
+++ b/Cluster.WebCrawler/src/WebCrawler.TrackerService/Program.cs
@@ -15,7 +15,11 @@ namespace WebCrawler.TrackerService
             var trackingService = new TrackerService();
             trackingService.Start();
 
-            Console.CancelKeyPress += (sender, eventArgs) => { trackingService.Stop(); };
+            Console.CancelKeyPress += (sender, eventArgs) =>
+            {
+                trackingService.Stop();
+                eventArgs.Cancel = true;
+            };
 
             trackingService.WhenTerminated.Wait();
         }


### PR DESCRIPTION
`Console.CancelKeyPress` event handler now prevents process from being terminated, giving the developer the chance to execute code after the `ActorSystem` is terminated.