### PR TITLE
move to persistence-based sharding, separate journals

### DIFF
--- a/src/clustering/sharding-sqlserver/SqlSharding.Host/Program.cs
+++ b/src/clustering/sharding-sqlserver/SqlSharding.Host/Program.cs
@@ -46,10 +46,10 @@ var builder = new HostBuilder()
                 .WithClustering(new ClusterOptions()
                     { Roles = new[] { ProductActorProps.SingletonActorRole }, SeedNodes = seeds })
                 .WithSqlServerPersistence(connectionString)
+                .AddHoconFile("sharding.conf", HoconAddMode.Prepend)
                 .AddHocon(@$"akka.persistence.journal.sharding.connection-string = ""{connectionString}""
                 akka.persistence.snapshot-store.sharding.connection-string = ""{connectionString}""
-                ")
-                .AddHoconFile("sharding.conf")
+                ", HoconAddMode.Prepend)
                 .WithShardRegion<ProductMarker>("products", s => ProductTotalsActor.GetProps(s),
                     new ProductMessageRouter(),
                     new ShardOptions()

--- a/src/clustering/sharding-sqlserver/SqlSharding.Host/Program.cs
+++ b/src/clustering/sharding-sqlserver/SqlSharding.Host/Program.cs
@@ -45,11 +45,7 @@ var builder = new HostBuilder()
                 .AddAppSerialization()
                 .WithClustering(new ClusterOptions()
                     { Roles = new[] { ProductActorProps.SingletonActorRole }, SeedNodes = seeds })
-                .WithSqlServerPersistence(connectionString)
-                .AddHoconFile("sharding.conf", HoconAddMode.Prepend)
-                .AddHocon(@$"akka.persistence.journal.sharding.connection-string = ""{connectionString}""
-                akka.persistence.snapshot-store.sharding.connection-string = ""{connectionString}""
-                ", HoconAddMode.Prepend)
+                .WithSqlServerPersistence(connectionString)               
                 .WithShardRegion<ProductMarker>("products", s => ProductTotalsActor.GetProps(s),
                     new ProductMessageRouter(),
                     new ShardOptions()
@@ -57,6 +53,10 @@ var builder = new HostBuilder()
                         RememberEntities = true, Role = ProductActorProps.SingletonActorRole,
                         StateStoreMode = StateStoreMode.Persistence
                     })
+                .AddHoconFile("sharding.conf", HoconAddMode.Prepend)
+                .AddHocon(@$"akka.persistence.journal.sharding.connection-string = ""{connectionString}""
+                akka.persistence.snapshot-store.sharding.connection-string = ""{connectionString}""
+                ", HoconAddMode.Prepend)
                 .StartActors((system, registry) =>
                 {
                     var shardRegion = registry.Get<ProductMarker>();

--- a/src/clustering/sharding-sqlserver/SqlSharding.Host/SqlSharding.Host.csproj
+++ b/src/clustering/sharding-sqlserver/SqlSharding.Host/SqlSharding.Host.csproj
@@ -33,5 +33,9 @@
       <Content Include="appsettings.Production.json">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>
+      <None Remove="sharding.conf" />
+      <Content Include="sharding.conf">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </Content>
     </ItemGroup>
 </Project>

--- a/src/clustering/sharding-sqlserver/SqlSharding.Host/sharding.conf
+++ b/src/clustering/sharding-sqlserver/SqlSharding.Host/sharding.conf
@@ -25,17 +25,19 @@ akka{
         }
         
         snapshot-store{
-            # qualified type name of the SQL Server persistence journal actor
-            class = "Akka.Persistence.SqlServer.Snapshot.SqlServerSnapshotStore, Akka.Persistence.SqlServer"
-
-            # connection string used for database access
-            connection-string = ""
-
-            # SQL server table corresponding with persistent journal
-            table-name = ShardingSnapshotStore
-
-            # should corresponding journal table be initialized automatically
-            auto-initialize = on
+            sharding{
+                # qualified type name of the SQL Server persistence journal actor
+                class = "Akka.Persistence.SqlServer.Snapshot.SqlServerSnapshotStore, Akka.Persistence.SqlServer"
+    
+                # connection string used for database access
+                connection-string = ""
+    
+                # SQL server table corresponding with persistent journal
+                table-name = ShardingSnapshotStore
+    
+                # should corresponding journal table be initialized automatically
+                auto-initialize = on
+            }           
         }
     }
 }

--- a/src/clustering/sharding-sqlserver/SqlSharding.Host/sharding.conf
+++ b/src/clustering/sharding-sqlserver/SqlSharding.Host/sharding.conf
@@ -1,0 +1,41 @@
+akka{
+    cluster.sharding{
+        # use separate journal implementations for Akka.Cluster.Sharding
+        journal-plugin-id = akka.persistence.journal.sharding
+        snapshot-plugin-id = akka.persistence.snapshot-store.sharding
+    }
+    
+    persistence{
+        journal{
+            sharding{
+                # qualified type name of the SQL Server persistence journal actor
+                class = "Akka.Persistence.SqlServer.Journal.SqlServerJournal, Akka.Persistence.SqlServer"
+                
+                # connection string used for database access
+                connection-string = ""
+                
+                # SQL server table corresponding with persistent journal
+                table-name = ShardingEventJournal
+                metadata-table-name = ShardingMetadata
+    
+                # should corresponding journal table be initialized automatically
+                auto-initialize = on
+
+            }
+        }
+        
+        snapshot-store{
+            # qualified type name of the SQL Server persistence journal actor
+            class = "Akka.Persistence.SqlServer.Snapshot.SqlServerSnapshotStore, Akka.Persistence.SqlServer"
+
+            # connection string used for database access
+            connection-string = ""
+
+            # SQL server table corresponding with persistent journal
+            table-name = ShardingSnapshotStore
+
+            # should corresponding journal table be initialized automatically
+            auto-initialize = on
+        }
+    }
+}

--- a/src/clustering/sharding-sqlserver/SqlSharding.WebApp/Program.cs
+++ b/src/clustering/sharding-sqlserver/SqlSharding.WebApp/Program.cs
@@ -16,7 +16,7 @@ var hostName = akkaSection.GetValue<string>("ClusterIp", "localhost");
 // maps to environment variable Akka__ClusterPort
 var port = akkaSection.GetValue<int>("ClusterPort", 7918);
 
-var seeds = akkaSection.GetValue<string[]>("ClusterSeeds", new []{ "akka.tcp://SqlSharding@localhost:7919" }).Select(Address.Parse)
+var seeds = akkaSection.GetValue<string[]>("ClusterSeeds", new []{ "akka.tcp://SqlSharding@localhost:7918" }).Select(Address.Parse)
     .ToArray();
 
 // Add services to the container.


### PR DESCRIPTION
Moving to using `state-store-mode = persistence` for Akka.Cluster.Sharding, and adopting the best practice of having separate journals and snapshot stores for Akka.Cluster.Sharding specifically.