### PR TITLE
fix: sqlcmd path

### DIFF
--- a/infrastructure/mssql/src/setup.sh
+++ b/infrastructure/mssql/src/setup.sh
@@ -8,6 +8,6 @@ sleep 15s
 
 # setup the tables
 echo "Connecting to SQL and creating Akka database."
-/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P ${SA_PASSWORD} -d master -i setup.sql
+/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P ${SA_PASSWORD} -d master -i setup.sql
 
 sleep infinity


### PR DESCRIPTION
This pull request updates the `setup.sh` script in the `infrastructure/mssql` directory to use the `sqlcmd` tool from the correct path. This is related to https://github.com/microsoft/mssql-docker/issues/892. Older image versions would work, but the `setup.sh` fails when targeting latest versions of the SQL Server image:

```
./setup.sh: line 11: /opt/mssql-tools/bin/sqlcmd: No such file or directory


2025-05-13 23:15:29.75 Logon       Error: 18456, Severity: 14, State: 38.
```

Current tool location:
![image](https://github.com/user-attachments/assets/0709cddc-850c-403a-b410-520f6654ec1e)