### PR TITLE
Add long-running tasks code sample with Akka.Streams + PipeTo

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -27,6 +27,7 @@ jobs:
           - AutofacIntegration
           - ReliableRabbitMQ
           - SqlInitContainer
+          - LongRunningTasks
         include:
           - solution-name: ShardingSqlServer
             solution-path: src/clustering/sharding-sqlserver/ShardingSqlServer.slnx
@@ -42,6 +43,8 @@ jobs:
             solution-path: src/reliability/rabbitmq-backpressure/ReliableRabbitMQ.slnx
           - solution-name: SqlInitContainer
             solution-path: infrastructure/mssql-init-container/src/Akka.SqlInitContainer.slnx
+          - solution-name: LongRunningTasks
+            solution-path: src/async/long-running-tasks/LongRunningTasks.slnx
     steps:
       - uses: actions/checkout@v6
         with:

--- a/src/async/long-running-tasks/LongRunningTasks.Tests/BatchImportActorSpecs.cs
+++ b/src/async/long-running-tasks/LongRunningTasks.Tests/BatchImportActorSpecs.cs
@@ -1,0 +1,171 @@
+using Akka.Actor;
+using Akka.Hosting;
+using Akka.Hosting.TestKit;
+using LongRunningTasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace LongRunningTasks.Tests;
+
+public class BatchImportActorSpecs : TestKit
+{
+    public BatchImportActorSpecs(ITestOutputHelper output) : base(nameof(BatchImportActorSpecs), output)
+    {
+    }
+
+    protected override void ConfigureAkka(AkkaConfigurationBuilder builder, IServiceProvider provider)
+    {
+        builder.WithActors((system, registry, resolver) =>
+        {
+            var importActor = system.ActorOf(
+                resolver.Props<BatchImportActor>(), "batch-importer");
+            registry.Register<BatchImportActor>(importActor);
+        });
+    }
+
+    private IActorRef ImportActor => ActorRegistry.Get<BatchImportActor>();
+
+    [Fact]
+    public async Task Should_complete_import_successfully()
+    {
+        // use a small dataset so the test finishes quickly
+        ImportActor.Tell(new StartImport(RecordCount: 500, BatchSize: 100));
+
+        // actor should eventually log completion — verify via status polling
+        await AwaitConditionAsync(async () =>
+        {
+            var status = await ImportActor.Ask<StatusResponse>(new GetStatus(), TimeSpan.FromSeconds(3));
+            return !status.IsActive && status.RecordsProcessed == 500;
+        }, max: TimeSpan.FromSeconds(30));
+
+        var final = await ImportActor.Ask<StatusResponse>(new GetStatus(), TimeSpan.FromSeconds(3));
+        Assert.Equal(500, final.RecordsProcessed);
+        Assert.Equal(500, final.TotalRecords);
+        Assert.False(final.IsActive);
+    }
+
+    [Fact]
+    public async Task Should_report_status_while_import_is_running()
+    {
+        // enough records that we can query mid-flight
+        ImportActor.Tell(new StartImport(RecordCount: 5000, BatchSize: 100));
+
+        // wait until import is active
+        await AwaitConditionAsync(async () =>
+        {
+            var status = await ImportActor.Ask<StatusResponse>(new GetStatus(), TimeSpan.FromSeconds(3));
+            return status.IsActive;
+        }, max: TimeSpan.FromSeconds(10));
+
+        // query status while running — the actor should respond (mailbox not blocked)
+        var midStatus = await ImportActor.Ask<StatusResponse>(new GetStatus(), TimeSpan.FromSeconds(3));
+        Assert.True(midStatus.IsActive);
+        Assert.Equal(5000, midStatus.TotalRecords);
+        Assert.True(midStatus.Elapsed > TimeSpan.Zero);
+    }
+
+    [Fact]
+    public async Task Should_cancel_running_import()
+    {
+        // large enough that we can cancel mid-flight
+        ImportActor.Tell(new StartImport(RecordCount: 50_000, BatchSize: 100));
+
+        // wait until import is actively processing
+        await AwaitConditionAsync(async () =>
+        {
+            var status = await ImportActor.Ask<StatusResponse>(new GetStatus(), TimeSpan.FromSeconds(3));
+            return status.IsActive && status.RecordsProcessed > 0;
+        }, max: TimeSpan.FromSeconds(10));
+
+        // cancel the import
+        ImportActor.Tell(new CancelImport());
+
+        // should stop and report not active, with fewer records than total
+        await AwaitConditionAsync(async () =>
+        {
+            var status = await ImportActor.Ask<StatusResponse>(new GetStatus(), TimeSpan.FromSeconds(3));
+            return !status.IsActive;
+        }, max: TimeSpan.FromSeconds(10));
+
+        var final = await ImportActor.Ask<StatusResponse>(new GetStatus(), TimeSpan.FromSeconds(3));
+        Assert.False(final.IsActive);
+        Assert.True(final.RecordsProcessed < 50_000,
+            $"Expected partial processing after cancel, but got {final.RecordsProcessed}/{final.TotalRecords}");
+    }
+
+    [Fact]
+    public async Task Should_reject_duplicate_start_while_importing()
+    {
+        ImportActor.Tell(new StartImport(RecordCount: 50_000, BatchSize: 100));
+
+        // wait until active
+        await AwaitConditionAsync(async () =>
+        {
+            var status = await ImportActor.Ask<StatusResponse>(new GetStatus(), TimeSpan.FromSeconds(3));
+            return status.IsActive;
+        }, max: TimeSpan.FromSeconds(10));
+
+        // second start should be rejected — actor replies with current status
+        var response = await ImportActor.Ask<StatusResponse>(
+            new StartImport(RecordCount: 100), TimeSpan.FromSeconds(3));
+        Assert.True(response.IsActive);
+        Assert.Equal(50_000, response.TotalRecords); // still the original import
+
+        // cleanup
+        ImportActor.Tell(new CancelImport());
+    }
+
+    [Fact]
+    public async Task Should_allow_new_import_after_completion()
+    {
+        // first import
+        ImportActor.Tell(new StartImport(RecordCount: 200, BatchSize: 100));
+        await AwaitConditionAsync(async () =>
+        {
+            var s = await ImportActor.Ask<StatusResponse>(new GetStatus(), TimeSpan.FromSeconds(3));
+            return !s.IsActive && s.RecordsProcessed == 200;
+        }, max: TimeSpan.FromSeconds(30));
+
+        // second import should work
+        ImportActor.Tell(new StartImport(RecordCount: 300, BatchSize: 100));
+        await AwaitConditionAsync(async () =>
+        {
+            var s = await ImportActor.Ask<StatusResponse>(new GetStatus(), TimeSpan.FromSeconds(3));
+            return !s.IsActive && s.RecordsProcessed == 300;
+        }, max: TimeSpan.FromSeconds(30));
+
+        var final = await ImportActor.Ask<StatusResponse>(new GetStatus(), TimeSpan.FromSeconds(3));
+        Assert.Equal(300, final.RecordsProcessed);
+        Assert.Equal(300, final.TotalRecords);
+    }
+
+    [Fact]
+    public async Task Should_allow_new_import_after_cancellation()
+    {
+        // start and cancel
+        ImportActor.Tell(new StartImport(RecordCount: 50_000, BatchSize: 100));
+        await AwaitConditionAsync(async () =>
+        {
+            var s = await ImportActor.Ask<StatusResponse>(new GetStatus(), TimeSpan.FromSeconds(3));
+            return s.IsActive && s.RecordsProcessed > 0;
+        }, max: TimeSpan.FromSeconds(10));
+
+        ImportActor.Tell(new CancelImport());
+        await AwaitConditionAsync(async () =>
+        {
+            var s = await ImportActor.Ask<StatusResponse>(new GetStatus(), TimeSpan.FromSeconds(3));
+            return !s.IsActive;
+        }, max: TimeSpan.FromSeconds(10));
+
+        // new import should complete successfully
+        ImportActor.Tell(new StartImport(RecordCount: 200, BatchSize: 100));
+        await AwaitConditionAsync(async () =>
+        {
+            var s = await ImportActor.Ask<StatusResponse>(new GetStatus(), TimeSpan.FromSeconds(3));
+            return !s.IsActive && s.RecordsProcessed == 200;
+        }, max: TimeSpan.FromSeconds(30));
+
+        var final = await ImportActor.Ask<StatusResponse>(new GetStatus(), TimeSpan.FromSeconds(3));
+        Assert.Equal(200, final.RecordsProcessed);
+    }
+}

--- a/src/async/long-running-tasks/LongRunningTasks.Tests/LongRunningTasks.Tests.csproj
+++ b/src/async/long-running-tasks/LongRunningTasks.Tests/LongRunningTasks.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(NetRuntime)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Akka.Hosting" Version="$(AkkaHostingVersion)" />
+    <PackageReference Include="Akka.Hosting.TestKit.Xunit2" Version="$(AkkaHostingVersion)" />
+    <PackageReference Include="Akka.Streams" Version="$(AkkaVersion)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
+    <PackageReference Include="xunit" Version="$(XunitVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\LongRunningTasks\LongRunningTasks.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/async/long-running-tasks/LongRunningTasks.slnx
+++ b/src/async/long-running-tasks/LongRunningTasks.slnx
@@ -1,0 +1,7 @@
+<Solution>
+  <Folder Name="/Solution Items/">
+    <File Path="README.md" />
+  </Folder>
+  <Project Path="LongRunningTasks/LongRunningTasks.csproj" />
+  <Project Path="LongRunningTasks.Tests/LongRunningTasks.Tests.csproj" />
+</Solution>

--- a/src/async/long-running-tasks/LongRunningTasks/BatchImportActor.cs
+++ b/src/async/long-running-tasks/LongRunningTasks/BatchImportActor.cs
@@ -1,0 +1,164 @@
+using System.Diagnostics;
+using Akka.Actor;
+using Akka.Event;
+using Akka.Streams;
+using Akka.Streams.Dsl;
+
+namespace LongRunningTasks;
+
+/// <summary>
+/// Demonstrates how to run long-running background work inside an Akka.NET actor
+/// without blocking the mailbox using the PipeTo + SharedKillSwitch pattern.
+/// </summary>
+public class BatchImportActor : ReceiveActor
+{
+    private bool _isImporting;
+    private CancellationTokenSource? _importCts;
+    private SharedKillSwitch? _killSwitch;
+    private int _recordsProcessed;
+    private int _totalRecords;
+    private readonly Stopwatch _stopwatch = new();
+    private readonly ILoggingAdapter _log = Context.GetLogger();
+
+    public BatchImportActor()
+    {
+        Receive<StartImport>(HandleStartImport);
+        Receive<GetStatus>(HandleGetStatus);
+        Receive<CancelImport>(HandleCancelImport);
+        Receive<ImportCompleted>(HandleImportCompleted);
+    }
+
+    private void HandleStartImport(StartImport msg)
+    {
+        if (_isImporting)
+        {
+            _log.Warning("Import already in progress — cancel current import first.");
+            Sender.Tell(new StatusResponse(_recordsProcessed, _totalRecords,
+                _stopwatch.Elapsed, _isImporting));
+            return;
+        }
+
+        _isImporting = true;
+        _recordsProcessed = 0;
+        _totalRecords = msg.RecordCount;
+        _stopwatch.Restart();
+
+        // Create cancellation handle and kill switch for the stream
+        _importCts?.Cancel();
+        _importCts?.Dispose();
+        _importCts = new CancellationTokenSource();
+        _killSwitch = KillSwitches.Shared("import-kill-switch");
+
+        var ct = _importCts.Token;
+        var batchSize = msg.BatchSize;
+        var csvRecords = FakeDataGenerator.Generate(msg.RecordCount);
+
+        // Capture the materializer while we're on the actor's thread
+        var materializer = Context.System.Materializer();
+
+        _log.Info("Starting import of {0} records in batches of {1}...",
+            msg.RecordCount, batchSize);
+
+        // KEY PATTERN: _ = RunStreamPipeline(...).PipeTo(Self)
+        // The critical fire-and-forget line. HandleStartImport returns immediately
+        // after this. The actor's mailbox is free to process GetStatus and CancelImport.
+        _ = RunStreamPipeline(csvRecords, batchSize, ct, materializer).PipeTo(Self);
+    }
+
+    private async Task<ImportCompleted> RunStreamPipeline(
+        List<CustomerRecord> csvRecords, int batchSize, CancellationToken ct,
+        IMaterializer materializer)
+    {
+        var recordsProcessed = 0;
+        try
+        {
+            ct.ThrowIfCancellationRequested();
+
+            await Source.From(csvRecords)
+                .Via(_killSwitch!.Flow<CustomerRecord>())
+                .Grouped(batchSize) // Process in batches
+                .SelectAsync(1, async batch =>
+                {
+                    // Simulate processing work per batch
+                    await Task.Delay(TimeSpan.FromMilliseconds(100), ct);
+                    return batch.Count();
+                })
+                .RunWith(Sink.Aggregate<int, int>(0, (total, count) =>
+                {
+                    recordsProcessed = total + count;
+                    // Side-channel: update actor's progress field
+                    // Safe because this field is only read (not written) by GetStatus
+                    _recordsProcessed = recordsProcessed;
+                    return recordsProcessed;
+                }), materializer);
+
+            return new ImportCompleted(recordsProcessed, _totalRecords, Success: true);
+        }
+        // Distinguishes intentional cancellation from unexpected timeouts
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            return new ImportCompleted(recordsProcessed, _totalRecords,
+                Success: false, "Import cancelled");
+        }
+        catch (Exception ex)
+        {
+            return new ImportCompleted(recordsProcessed, _totalRecords,
+                Success: false, ex.Message);
+        }
+    }
+
+    private void HandleGetStatus(GetStatus _)
+    {
+        // This works even while the import stream is running,
+        // proving the actor's mailbox is not blocked.
+        Sender.Tell(new StatusResponse(
+            _recordsProcessed, _totalRecords, _stopwatch.Elapsed, _isImporting));
+    }
+
+    private void HandleCancelImport(CancelImport _)
+    {
+        if (!_isImporting)
+        {
+            _log.Info("No import in progress to cancel.");
+            return;
+        }
+
+        _log.Info("Cancelling import...");
+
+        // SharedKillSwitch is Akka.Streams' built-in mechanism to abort a running stream
+        _killSwitch?.Shutdown();
+        _importCts?.Cancel();
+        _importCts?.Dispose();
+        _importCts = null;
+        _isImporting = false;
+        _stopwatch.Stop();
+    }
+
+    private void HandleImportCompleted(ImportCompleted msg)
+    {
+        _isImporting = false;
+        _stopwatch.Stop();
+
+        if (msg.Success)
+        {
+            _log.Info("Import completed successfully. Processed {0}/{1} records in {2:F1}s.",
+                msg.RecordsProcessed, msg.TotalRecords, _stopwatch.Elapsed.TotalSeconds);
+        }
+        else
+        {
+            _log.Warning("Import finished: {0}. Processed {1}/{2} records.",
+                msg.Error, msg.RecordsProcessed, msg.TotalRecords);
+        }
+    }
+
+    // PostStop uses sync Cancel() because PostStop is synchronous.
+    // ReceiveAsync handlers can use await CancelAsync() instead.
+    protected override void PostStop()
+    {
+        _killSwitch?.Shutdown();
+        _importCts?.Cancel();
+        _importCts?.Dispose();
+        _importCts = null;
+        base.PostStop();
+    }
+}

--- a/src/async/long-running-tasks/LongRunningTasks/CustomerRecord.cs
+++ b/src/async/long-running-tasks/LongRunningTasks/CustomerRecord.cs
@@ -1,0 +1,11 @@
+namespace LongRunningTasks;
+
+public record CustomerRecord
+{
+    public int Id { get; init; }
+    public string Name { get; init; } = string.Empty;
+    public string Email { get; init; } = string.Empty;
+    public string Address { get; init; } = string.Empty;
+    public int OrderCount { get; init; }
+    public decimal TotalSpent { get; init; }
+}

--- a/src/async/long-running-tasks/LongRunningTasks/FakeDataGenerator.cs
+++ b/src/async/long-running-tasks/LongRunningTasks/FakeDataGenerator.cs
@@ -1,0 +1,19 @@
+using Bogus;
+
+namespace LongRunningTasks;
+
+public static class FakeDataGenerator
+{
+    public static List<CustomerRecord> Generate(int count)
+    {
+        var faker = new Faker<CustomerRecord>()
+            .RuleFor(c => c.Id, f => f.IndexFaker + 1)
+            .RuleFor(c => c.Name, f => f.Name.FullName())
+            .RuleFor(c => c.Email, f => f.Internet.Email())
+            .RuleFor(c => c.Address, f => f.Address.FullAddress())
+            .RuleFor(c => c.OrderCount, f => f.Random.Int(0, 100))
+            .RuleFor(c => c.TotalSpent, f => f.Finance.Amount(0, 10000));
+
+        return faker.Generate(count);
+    }
+}

--- a/src/async/long-running-tasks/LongRunningTasks/LongRunningTasks.csproj
+++ b/src/async/long-running-tasks/LongRunningTasks/LongRunningTasks.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$(NetRuntime)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Akka.Hosting" Version="$(AkkaHostingVersion)" />
+    <PackageReference Include="Akka.Streams" Version="$(AkkaVersion)" />
+    <PackageReference Include="Bogus" Version="35.6.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MicrosoftExtensionsVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/src/async/long-running-tasks/LongRunningTasks/Messages.cs
+++ b/src/async/long-running-tasks/LongRunningTasks/Messages.cs
@@ -1,0 +1,11 @@
+namespace LongRunningTasks;
+
+public record StartImport(int RecordCount = 10_000, int BatchSize = 100);
+
+public record GetStatus;
+
+public record StatusResponse(int RecordsProcessed, int TotalRecords, TimeSpan Elapsed, bool IsActive);
+
+public record CancelImport;
+
+public record ImportCompleted(int RecordsProcessed, int TotalRecords, bool Success, string? Error = null);

--- a/src/async/long-running-tasks/LongRunningTasks/Program.cs
+++ b/src/async/long-running-tasks/LongRunningTasks/Program.cs
@@ -1,0 +1,86 @@
+using Akka.Actor;
+using Akka.Hosting;
+using LongRunningTasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+var host = Host.CreateDefaultBuilder(args)
+    .ConfigureServices((context, services) =>
+    {
+        services.AddAkka("ImportSystem", (builder, sp) =>
+        {
+            builder.WithActors((system, registry, resolver) =>
+            {
+                var importActor = system.ActorOf(
+                    resolver.Props<BatchImportActor>(), "batch-importer");
+                registry.Register<BatchImportActor>(importActor);
+            });
+        });
+    })
+    .Build();
+
+await host.StartAsync();
+
+var actorRegistry = host.Services.GetRequiredService<ActorRegistry>();
+var importActor = actorRegistry.Get<BatchImportActor>();
+
+Console.WriteLine("=== Akka.NET Long-Running Tasks Demo ===");
+Console.WriteLine("Commands:");
+Console.WriteLine("  start [count]  - Generate fake data and start import (default: 10000)");
+Console.WriteLine("  status         - Query actor status while import runs");
+Console.WriteLine("  cancel         - Cancel the running import");
+Console.WriteLine("  quit           - Graceful shutdown");
+Console.WriteLine();
+
+while (true)
+{
+    Console.Write("> ");
+    var input = Console.ReadLine()?.Trim();
+    if (string.IsNullOrEmpty(input)) continue;
+
+    var parts = input.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+    switch (parts[0].ToLowerInvariant())
+    {
+        case "start":
+            var count = parts.Length > 1 && int.TryParse(parts[1], out var c) ? c : 10_000;
+            importActor.Tell(new StartImport(count));
+            Console.WriteLine($"  Sent StartImport({count:N0}) to actor.");
+            break;
+
+        case "status":
+            try
+            {
+                var status = await importActor.Ask<StatusResponse>(
+                    new GetStatus(), TimeSpan.FromSeconds(3));
+                Console.WriteLine($"  Active:   {status.IsActive}");
+                Console.WriteLine($"  Progress: {status.RecordsProcessed:N0} / {status.TotalRecords:N0}");
+                if (status.TotalRecords > 0)
+                {
+                    var pct = (double)status.RecordsProcessed / status.TotalRecords * 100;
+                    Console.WriteLine($"  Complete: {pct:F1}%");
+                }
+                Console.WriteLine($"  Elapsed:  {status.Elapsed:mm\\:ss\\.ff}");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"  Failed to get status: {ex.Message}");
+            }
+            break;
+
+        case "cancel":
+            importActor.Tell(new CancelImport());
+            Console.WriteLine("  Sent CancelImport to actor.");
+            break;
+
+        case "quit":
+        case "exit":
+            Console.WriteLine("  Shutting down...");
+            await host.StopAsync();
+            return;
+
+        default:
+            Console.WriteLine("  Unknown command. Try: start, status, cancel, quit");
+            break;
+    }
+}

--- a/src/async/long-running-tasks/README.md
+++ b/src/async/long-running-tasks/README.md
@@ -1,0 +1,84 @@
+# Long-Running Tasks in Akka.NET Actors
+
+Demonstrates how to run long-running background work inside an Akka.NET actor without blocking the mailbox, using the **detached Task + PipeTo + SharedKillSwitch** pattern with Akka.Streams.
+
+## Technology
+
+- [Akka.NET](https://getakka.net/)
+- [Akka.Hosting](https://github.com/akkadotnet/Akka.Hosting)
+- [Akka.Streams](https://getakka.net/articles/streams/introduction.html)
+- [Bogus](https://github.com/bchavez/Bogus) (fake data generation)
+
+## Domain
+
+A `BatchImportActor` processes a large CSV-like dataset using an Akka.Streams pipeline. The import runs in the background while the actor remains responsive to status queries and cancellation requests.
+
+## Running This Sample
+
+```shell
+cd src/async/long-running-tasks/LongRunningTasks
+dotnet run
+```
+
+### Available Commands
+
+| Command | Description |
+|---------|-------------|
+| `start [count]` | Generate fake customer records and start import (default: 10,000) |
+| `status` | Query the actor's progress while the import runs |
+| `cancel` | Cancel the running import via SharedKillSwitch |
+| `quit` | Graceful shutdown |
+
+### Example Session
+
+```
+> start
+  Sent StartImport(10,000) to actor.
+> status
+  Active:   True
+  Progress: 3,200 / 10,000
+  Complete: 32.0%
+  Elapsed:  00:03.21
+> status
+  Active:   True
+  Progress: 7,800 / 10,000
+  Complete: 78.0%
+  Elapsed:  00:07.85
+> cancel
+  Sent CancelImport to actor.
+```
+
+## Key Code Sections
+
+### 1. Fire-and-Forget with PipeTo (`BatchImportActor.cs`)
+
+```csharp
+_ = RunStreamPipeline(csvRecords, batchSize, ct, materializer).PipeTo(Self);
+```
+
+This is the critical line. `HandleStartImport` returns immediately after calling `PipeTo`. The stream runs on background threads while the actor's mailbox stays free to process `GetStatus` and `CancelImport` messages.
+
+### 2. SharedKillSwitch for Stream Cancellation
+
+`SharedKillSwitch` is Akka.Streams' built-in mechanism to abort a running stream from outside. The actor holds a reference to the kill switch and calls `Shutdown()` when cancellation is requested.
+
+### 3. CancellationTokenSource as Actor State
+
+The actor owns a `CancellationTokenSource` field — the handle for cancelling in-flight async work. `PostStop` uses synchronous `Cancel()` because `PostStop` is synchronous; regular message handlers could use `await CancelAsync()` instead.
+
+### 4. Progress Reporting While Import Runs
+
+The actor responds to `GetStatus` queries during the import, proving the mailbox is not blocked. The stream updates a progress field via a side-channel in the `Sink.Aggregate` callback.
+
+### 5. Intentional vs. Unexpected Cancellation
+
+```csharp
+catch (OperationCanceledException) when (ct.IsCancellationRequested)
+```
+
+The `when` guard distinguishes intentional user cancellation from unexpected timeouts or other errors.
+
+## Resources
+
+- [Async/Await and PipeTo in Akka.NET](https://getakka.net/articles/actors/receive-actor-api.html#async-and-await)
+- [Akka.Streams Documentation](https://getakka.net/articles/streams/introduction.html)


### PR DESCRIPTION
## Summary
- Adds new `src/async/long-running-tasks/` sample demonstrating how to run long-running background work inside an Akka.NET actor without blocking the mailbox
- Uses the **detached Task + PipeTo + SharedKillSwitch** pattern with Akka.Streams to process a large dataset while the actor stays responsive to status queries and cancellation
- Includes 6 end-to-end tests covering completion, mid-flight status, cancellation, duplicate-start rejection, and restart-after-cancel
- Adds the new sample to the CI matrix in `pr_validation.yml`

## Test plan
- [x] `dotnet build` succeeds with 0 errors, 0 warnings
- [x] `dotnet test` passes all 6 tests locally
- [ ] CI matrix passes for `LongRunningTasks` on both ubuntu-latest and windows-latest